### PR TITLE
Secutiry - Disable expose_php

### DIFF
--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -18,6 +18,6 @@
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'
 - name: disable expose_php
-  lineinfile: dest=/etc/php5/fpm/php.ini
+  lineinfile: dest="{{php_config_prefix}}/fpm/php.ini"
               regexp=';?expose_php=\d'
               line='expose_php=0'

--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -17,3 +17,7 @@
   lineinfile: dest="{{php_config_prefix}}/fpm/php.ini"
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'
+- name: disable expose_php
+  lineinfile: dest=/etc/php5/fpm/php.ini
+              regexp=';?expose_php=\d'
+              line='expose_php=0'


### PR DESCRIPTION
Secutiry - Disable expose_php, it hidde the php version in response header (e.g., X-Powered-By: PHP/5.3.7)
