### PR TITLE
Replace sudo commands with become

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: Add ppa Repository
-  sudo: yes
+  become: yes
   apt_repository: repo=ppa:ondrej/{{ php.ppa }}
 
 - name: Ensure packages database is up to date
-  sudo: yes
+  become: yes
   apt: update_cache=yes
 
 - name: Install php
-  sudo: yes
+  become: yes
   apt: pkg="{{php_version}}" state=latest
 
 - name: Install php-fpm
-  sudo: yes
+  become: yes
   apt: pkg="{{php_version}}-fpm" state=latest
 
 - name: Install PHP Packages
-  sudo: yes
+  become: yes
   apt: pkg={{ item }} state=latest
   with_items: php.packages
   when: php.packages is defined


### PR DESCRIPTION
Issue: [phansible/phansible/issues/273](https://github.com/phansible/phansible/issues/273)

Replace all `sudo` command references for the `become` one, since `sudo` will be deprecated soon
