### PR TITLE
Updates role for compatibility with ppa:ondrej/php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ script:
   - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"
 
   # Run the role/playbook again, checking to make sure it's idempotent.
+  # Changed is 1 as the packages database will update
   - >
     ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo
-    | grep -q 'changed=0.*failed=0'
+    | grep -q 'changed=1.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,13 @@
 ---
 server:
     timezone: "Europe/London"
-php:
-    ppa: "php5-5.6"
-    packages: ["php5-cli", "php5-intl", "php5-mcrypt"]
 
-php_version: "{% if php.ppa == 'php-7.0' %}php7.0{% else %}php5{% endif %}"
-php_config_prefix: "{% if php.ppa == 'php-7.0' %}/etc/php/7.0{% else %}/etc/php5{% endif %}"
+php:
+    ppa: "php"
+    packages:
+        - "cli"
+        - "intl"
+        - "mcrypt"
+
+php_version: 5.6
+php_config_prefix: "/etc/php/{{php_version}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@ server:
     timezone: "Europe/London"
 
 php:
-    ppa: "php"
     packages:
         - "cli"
         - "intl"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart php-fpm
-  service: name="php{{php_version}}-fpm" enabled=yes state=restarted
+  service: name="php{{ php_version }}-fpm" enabled=yes state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart php-fpm
-  service: name="{{php_version}}-fpm" enabled=yes state=restarted
+  service: name="php{{php_version}}-fpm" enabled=yes state=restarted

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,11 +1,11 @@
 ---
-- stat: path="{{php_config_prefix}}/apache2/php.ini"
+- stat: path="{{ php_config_prefix }}/apache2/php.ini"
   register: modphp
 
-- stat: path="{{php_config_prefix}}/fpm/php.ini"
+- stat: path="{{ php_config_prefix }}/fpm/php.ini"
   register: phpfpm
 
-- stat: path="{{php_config_prefix}}/cli/php.ini"
+- stat: path="{{ php_config_prefix }}/cli/php.ini"
   register: phpcli
 
 - include: php-fpm.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add ppa Repository
   become: yes
-  apt_repository: repo=ppa:ondrej/{{ php.ppa }}
+  apt_repository: repo=ppa:ondrej/{{php.ppa}}
 
 - name: Ensure packages database is up to date
   become: yes
@@ -9,16 +9,16 @@
 
 - name: Install php
   become: yes
-  apt: pkg="{{php_version}}" state=latest
+  apt: pkg="php{{php_version}}" state=latest
 
 - name: Install php-fpm
   become: yes
-  apt: pkg="{{php_version}}-fpm" state=latest
+  apt: pkg="php{{php_version}}-fpm" state=latest
 
 - name: Install PHP Packages
   become: yes
-  apt: pkg={{ item }} state=latest
-  with_items: php.packages
+  apt: pkg=php{{php_version}}-{{item}} state=latest
+  with_items: "{{php.packages}}"
   when: php.packages is defined
 
 - include: configure.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add ppa Repository
   become: yes
-  apt_repository: repo=ppa:ondrej/{{php.ppa}}
+  apt_repository: repo=ppa:ondrej/php
 
 - name: Ensure packages database is up to date
   become: yes
@@ -9,17 +9,18 @@
 
 - name: Install php
   become: yes
-  apt: pkg="php{{php_version}}" state=latest
+  apt: pkg="php{{ php_version }}" state=latest
 
 - name: Install php-fpm
   become: yes
-  apt: pkg="php{{php_version}}-fpm" state=latest
+  apt: pkg="php{{ php_version }}-fpm" state=latest
 
 - name: Install PHP Packages
   become: yes
-  apt: pkg=php{{php_version}}-{{item}} state=latest
-  with_items: "{{php.packages}}"
+  apt: pkg=php{{ php_version }}-{{ item }} state=latest
+  with_items: "{{ php.packages }}"
   when: php.packages is defined
 
 - include: configure.yml
+
 - include: pecl.yml

--- a/tasks/mod-php.yml
+++ b/tasks/mod-php.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure timezone is set in apache2 php.ini
-  lineinfile: dest="{{php_config_prefix}}/apache2/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/apache2/php.ini"
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache
-  lineinfile: dest="{{php_config_prefix}}/apache2/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/apache2/php.ini"
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'

--- a/tasks/pecl.yml
+++ b/tasks/pecl.yml
@@ -1,5 +1,5 @@
 - name: Install php-dev
-  apt: pkg="{{php_version}}-dev" state=present
+  apt: pkg="{{ php_version }}-dev" state=present
   when: php.peclpackages is defined
 
 - name: Install Package
@@ -7,20 +7,20 @@
   register: pecl_result
   changed_when: "'already installed' not in pecl_result.stdout"
   failed_when: "pecl_result.stderr or ('ERROR' in pecl_result.stdout)"
-  with_items: php.peclpackages
+  with_items: "{{ php.peclpackages }}"
   when: php.peclpackages is defined
 
 - name: Create extension .ini file
   template: >
     src="extension.tpl"
-    dest="{{php_config_prefix}}/mods-available/{{ item }}.ini"
+    dest="{{ php_config_prefix }}/mods-available/{{ item }}.ini"
     owner="root"
     group="root"
     mode=0644
-  with_items: php.peclpackages
+  with_items: "{{ php.peclpackages }}"
   when: php.peclpackages is defined
 
 - name: Enable extension
   shell: "phpenmod {{ item }}"
-  with_items: php.peclpackages
+  with_items: "{{ php.peclpackages }}"
   when: php.peclpackages is defined

--- a/tasks/pecl.yml
+++ b/tasks/pecl.yml
@@ -21,6 +21,6 @@
   when: php.peclpackages is defined
 
 - name: Enable extension
-  shell: "{% if php_version == 'php5' %}php5enmod{% else %}phpenmod{% endif %} {{ item }}"
+  shell: "phpenmod {{ item }}"
   with_items: php.peclpackages
   when: php.peclpackages is defined

--- a/tasks/php-cli.yml
+++ b/tasks/php-cli.yml
@@ -1,10 +1,10 @@
 ---
 - name: ensure timezone is set in cli php.ini
-  lineinfile: dest="{{php_config_prefix}}/cli/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/cli/php.ini"
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 
 - name: enabling opcache cli
-  lineinfile: dest="{{php_config_prefix}}/cli/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/cli/php.ini"
               regexp=';?opcache.enable_cli=\d'
               line='opcache.enable_cli=1'

--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -1,23 +1,23 @@
 ---
 - name: Set permissions on socket - owner
-  lineinfile: "dest={{php_config_prefix}}/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
+  lineinfile: "dest={{ php_config_prefix }}/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
 
 - name: Set permissions on socket - group
-  lineinfile: "dest={{php_config_prefix}}/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
+  lineinfile: "dest={{ php_config_prefix }}/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
 
 - name: Set permissions on socket - mode
-  lineinfile: "dest={{php_config_prefix}}/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
+  lineinfile: "dest={{ php_config_prefix }}/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
   notify: restart php-fpm
 
 - name: ensure timezone is set in fpm php.ini
-  lineinfile: dest="{{php_config_prefix}}/fpm/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/fpm/php.ini"
               regexp='date.timezone ='
               line='date.timezone = {{ server.timezone }}'
 - name: enabling opcache
-  lineinfile: dest="{{php_config_prefix}}/fpm/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/fpm/php.ini"
               regexp=';?opcache.enable=\d'
               line='opcache.enable=1'
 - name: disable expose_php
-  lineinfile: dest="{{php_config_prefix}}/fpm/php.ini"
+  lineinfile: dest="{{ php_config_prefix }}/fpm/php.ini"
               regexp=';?expose_php=\d'
               line='expose_php=0'


### PR DESCRIPTION
See initial discussion in #10 

Further things:

Maybe just make `phpX.Y-fpm` a part of `php.packages` by adding it as `fpm` rather than it having it's own task?
What about compatibility with `ppa:ondrej/php5-compat`? The changes I've made are assuming that the repo will be `ppa:ondrej/php` - but the PPA can still be changed - would need further work to investigate what should be done for `ppa:ondrej/php5-compat` - or just go with `ppa:ondrej/php` and make the repo non-configurable?